### PR TITLE
Fix: prevent duplicate SendEmailVerificationNotification registration

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace mvd81\laravelHorizonTagSearchInPendingAndCompletedJobs\Providers;
 
-use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
 use Laravel\Horizon\Events\JobDeleted;
 use Laravel\Horizon\Events\JobPushed;
 use mvd81\laravelHorizonTagSearchInPendingAndCompletedJobs\Listeners\ForgetJobInPendingTags;
@@ -11,20 +12,12 @@ use mvd81\laravelHorizonTagSearchInPendingAndCompletedJobs\Listeners\StoreTagsFo
 
 class EventServiceProvider extends ServiceProvider
 {
-    protected $listen = [
-
-        JobPushed::class => [
-            StoreTagsForPendingJob::class
-        ],
-        JobDeleted::class => [
-            ForgetJobInPendingTags::class,
-            StoreTagsForCompletedJob::class
-        ],
-
-    ];
-
-    public function boot()
+    public function register(): void
     {
-        parent::boot();
+        $this->booting(function () {
+            Event::listen(JobPushed::class, StoreTagsForPendingJob::class);
+            Event::listen(JobDeleted::class, ForgetJobInPendingTags::class);
+            Event::listen(JobDeleted::class, StoreTagsForCompletedJob::class);
+        });
     }
 }


### PR DESCRIPTION
## Problem

The package's `EventServiceProvider` extends `Illuminate\Foundation\Support\Providers\EventServiceProvider`. This base class includes a `configureEmailVerification()` method that automatically registers `SendEmailVerificationNotification` for the `Registered` event when it's not present in the `$listen` array.

Since this package's `$listen` only contains Horizon job events, the condition always evaluates to true — causing **every application using this package** to get an additional email verification listener. This results in **duplicate verification emails** being sent on user registration.

## Fix

Change the base class from `Illuminate\Foundation\Support\Providers\EventServiceProvider` to `Illuminate\Support\ServiceProvider`, which does not carry the email verification auto-configuration. The event listeners are registered manually via `Event::listen()` in the `booting` callback, preserving the same behavior.

## Before / After

**Before:** `php artisan event:list --event=Registered` shows the listener twice:
```
Illuminate\Auth\Events\Registered
  ⇂ Illuminate\Auth\Listeners\SendEmailVerificationNotification
  ⇂ Illuminate\Auth\Listeners\SendEmailVerificationNotification
```

**After:** Only one listener:
```
Illuminate\Auth\Events\Registered
  ⇂ Illuminate\Auth\Listeners\SendEmailVerificationNotification
```

Fixes #2